### PR TITLE
Added an IPMI library which would help the quanta plugin to fetch the power status of an IPMI controller (BMC).

### DIFF
--- a/modules/quanta-dummy-plugin/src/main/java/com/vmware/vrack/hms/plugin/boardservice/BoardService_Dummy.java
+++ b/modules/quanta-dummy-plugin/src/main/java/com/vmware/vrack/hms/plugin/boardservice/BoardService_Dummy.java
@@ -16,6 +16,7 @@
 
 package com.vmware.vrack.hms.plugin.boardservice;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -54,6 +55,7 @@ import com.vmware.vrack.hms.common.servernodes.api.hdd.HddInfo;
 import com.vmware.vrack.hms.common.servernodes.api.memory.PhysicalMemory;
 import com.vmware.vrack.hms.common.servernodes.api.storagecontroller.StorageControllerInfo;
 import com.vmware.vrack.hms.plugin.ServerPluginConstants;
+import com.vmware.vrack.hms.plugin.command.chassis.ChassisState;
 
 /*
  * This is a sample code which services the OOB agent requests with dummy data.
@@ -64,6 +66,8 @@ import com.vmware.vrack.hms.plugin.ServerPluginConstants;
 public class BoardService_Dummy
     implements IBoardService
 {
+    private String command;
+
     private List<BoardInfo> supportedBoards;
 
     private static Logger logger = Logger.getLogger( BoardService_Dummy.class );
@@ -75,6 +79,13 @@ public class BoardService_Dummy
     public BoardService_Dummy()
     {
         super();
+
+        String osName = System.getProperty( "os.name" );
+        if ( osName.contains( "Windows" ) )
+            command = System.getProperty( "user.home" ) + "\\Win-ipmiutil\\ipmiutil";
+        else if ( osName.contains( "Linux" ) )
+            command = "ipmiutil";
+
         BoardInfo boardInfo = new BoardInfo();
         boardInfo.setBoardManufacturer( ServerPluginConstants.BOARD_MANUFACTURER );
         boardInfo.setBoardProductName( ServerPluginConstants.BOARD_NAME );
@@ -94,6 +105,16 @@ public class BoardService_Dummy
     public List<BoardInfo> getSupportedBoard()
     {
         return supportedBoards;
+    }
+
+    public String getCommand()
+    {
+        return command;
+    }
+
+    public void setCommand( String command )
+    {
+        this.command = command;
     }
 
     @Override
@@ -139,39 +160,48 @@ public class BoardService_Dummy
     public boolean getServerPowerStatus( ServiceHmsNode serviceHmsNode )
         throws HmsException
     {
-        return power_status;
+        try
+        {
+            return ChassisState.getChassisPowerStatus( serviceHmsNode, this.getCommand() );
+        }
+        catch ( IOException e )
+        {
+            throw new HmsException( e );
+        }
     }
 
     @Override
     public boolean powerOperations( ServiceHmsNode serviceHmsNode, PowerOperationAction powerOperationAction )
         throws HmsException
     {
-        switch ( powerOperationAction )
+        try
         {
-            case COLDRESET:
-                power_status = true;
-                host_manageable = true;
-                break;
-            case HARDRESET:
-                power_status = true;
-                host_manageable = true;
-                break;
-            case POWERCYCLE:
-                power_status = true;
-                host_manageable = true;
-                break;
-            case POWERDOWN:
-                power_status = false;
-                host_manageable = false;
-                break;
-            case POWERUP:
-                power_status = true;
-                host_manageable = true;
-                break;
-            default:
-                break;
+            switch ( powerOperationAction )
+            {
+                case COLDRESET:
+                    host_manageable = true;
+                    return ChassisState.coldResetChassis( serviceHmsNode, command );
+                case HARDRESET:
+                    host_manageable = true;
+                    return ChassisState.hardResetChassis( serviceHmsNode, command );
+                case POWERCYCLE:
+                    host_manageable = true;
+                    return ChassisState.powerCycleChassis( serviceHmsNode, command );
+                case POWERDOWN:
+                    host_manageable = false;
+                    return ChassisState.powerDownChassis( serviceHmsNode, command );
+                case POWERUP:
+                    host_manageable = true;
+                    return ChassisState.powerUpChassis( serviceHmsNode, command );
+                default:
+                    break;
+            }
+            return false;
         }
-        return true;
+        catch ( IOException e )
+        {
+            throw new HmsException( e );
+        }
     }
 
     @Override

--- a/modules/quanta-dummy-plugin/src/main/java/com/vmware/vrack/hms/plugin/command/Command.java
+++ b/modules/quanta-dummy-plugin/src/main/java/com/vmware/vrack/hms/plugin/command/Command.java
@@ -1,0 +1,17 @@
+package com.vmware.vrack.hms.plugin.command;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Command
+{
+    public static BufferedReader executeCommand( String commandStr )
+        throws IOException
+    {
+        Process p = Runtime.getRuntime().exec( commandStr );
+        BufferedReader br = new BufferedReader( new InputStreamReader( p.getInputStream() ) );
+        return br;
+    }
+
+}

--- a/modules/quanta-dummy-plugin/src/main/java/com/vmware/vrack/hms/plugin/command/chassis/ChassisState.java
+++ b/modules/quanta-dummy-plugin/src/main/java/com/vmware/vrack/hms/plugin/command/chassis/ChassisState.java
@@ -1,0 +1,114 @@
+package com.vmware.vrack.hms.plugin.command.chassis;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.vmware.vrack.hms.common.boardvendorservice.resource.ServiceHmsNode;
+import com.vmware.vrack.hms.plugin.command.Command;
+
+public class ChassisState
+{
+    private static final Pattern chassisPower = Pattern.compile( "chassis_power += (.*)" ),
+                    resetEndMessage = Pattern.compile( "ipmiutil reset, completed successfully" );
+
+    public static boolean getChassisPowerStatus( ServiceHmsNode serviceHmsNode, String command )
+        throws IOException
+    {
+        String commandStr = command + " health" + " -N " + serviceHmsNode.getManagementIp() + " -U "
+            + serviceHmsNode.getManagementUserName() + " -P " + serviceHmsNode.getManagementUserPassword() + " -J 3";
+        BufferedReader br = Command.executeCommand( commandStr );
+        String line;
+        while ( ( line = br.readLine() ) != null )
+        {
+            Matcher matcher = chassisPower.matcher( line );
+            if ( matcher.find() )
+                return ( matcher.group( 1 ).contains( "on" ) ? true : false );
+
+        }
+
+        return false;
+    }
+
+    public static boolean powerUpChassis( ServiceHmsNode serviceHmsNode, String command )
+        throws IOException
+    {
+        String commandStr = command + " reset -u" + " -N " + serviceHmsNode.getManagementIp() + " -U "
+            + serviceHmsNode.getManagementUserName() + " -P " + serviceHmsNode.getManagementUserPassword() + " -J 3";
+        BufferedReader br = Command.executeCommand( commandStr );
+        String line;
+        while ( ( line = br.readLine() ) != null )
+        {
+            Matcher matcher = resetEndMessage.matcher( line );
+            if ( matcher.find() )
+                return true;
+        }
+        return false;
+    }
+
+    public static boolean powerDownChassis( ServiceHmsNode serviceHmsNode, String command )
+        throws IOException
+    {
+        String commandStr = command + " reset -d" + " -N " + serviceHmsNode.getManagementIp() + " -U "
+            + serviceHmsNode.getManagementUserName() + " -P " + serviceHmsNode.getManagementUserPassword() + " -J 3";
+        BufferedReader br = Command.executeCommand( commandStr );
+        String line;
+        while ( ( line = br.readLine() ) != null )
+        {
+            Matcher matcher = resetEndMessage.matcher( line );
+            if ( matcher.find() )
+                return true;
+        }
+        return false;
+    }
+
+    public static boolean powerCycleChassis( ServiceHmsNode serviceHmsNode, String command )
+        throws IOException
+    {
+        String commandStr = command + " reset -c" + " -N " + serviceHmsNode.getManagementIp() + " -U "
+            + serviceHmsNode.getManagementUserName() + " -P " + serviceHmsNode.getManagementUserPassword() + " -J 3";
+        BufferedReader br = Command.executeCommand( commandStr );
+        String line;
+        while ( ( line = br.readLine() ) != null )
+        {
+            Matcher matcher = resetEndMessage.matcher( line );
+            if ( matcher.find() )
+                return true;
+        }
+        return false;
+    }
+
+    public static boolean hardResetChassis( ServiceHmsNode serviceHmsNode, String command )
+        throws IOException
+    {
+        String commandStr = command + " reset -r" + " -N " + serviceHmsNode.getManagementIp() + " -U "
+            + serviceHmsNode.getManagementUserName() + " -P " + serviceHmsNode.getManagementUserPassword() + " -J 3";
+        BufferedReader br = Command.executeCommand( commandStr );
+        String line;
+        while ( ( line = br.readLine() ) != null )
+        {
+            Matcher matcher = resetEndMessage.matcher( line );
+            if ( matcher.find() )
+                return true;
+        }
+        return false;
+    }
+
+    public static boolean coldResetChassis( ServiceHmsNode serviceHmsNode, String command )
+        throws IOException
+    {
+        String commandStr = command + " reset -k" + " -N " + serviceHmsNode.getManagementIp() + " -U "
+            + serviceHmsNode.getManagementUserName() + " -P " + serviceHmsNode.getManagementUserPassword() + " -J 3";
+        BufferedReader br = Command.executeCommand( commandStr );
+        String line;
+        while ( ( line = br.readLine() ) != null )
+        {
+            Matcher matcher = resetEndMessage.matcher( line );
+            if ( matcher.find() )
+                return true;
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
Apart from fetching the power status, it can also perform some power operations, viz. powercycle, powerup, powerdown, hardreset, coldreset.

The requirement for this plugin to work is that:

1. In **Windows**, the user has to create a folder with name **_Win-ipmiutil_** in their home directory. After the creation one has to download a binary named, ipmiutil from their website (available in zip format) and extract it into the newly created directory, **_Win-ipmiutil_**

2. In **Linux**, the user has to download the debian package of ipmiutil from their website and install it in their system using command _**dpkg -i ipmiutil.deb**_, where ipmiutil.deb is the name of the debian package downloaded.